### PR TITLE
Bump version number

### DIFF
--- a/ada-light-mode.el
+++ b/ada-light-mode.el
@@ -5,7 +5,7 @@
 ;; Author: Sebastian Poeplau <sebastian.poeplau@mailbox.org>
 ;; Keywords: languages
 ;; URL: https://github.com/sebastianpoeplau/ada-light-mode
-;; Version: 0.1
+;; Version: 0.2
 ;; Package-Requires: ((emacs "24.3") (compat "29.1"))
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
I noticed some updated to ada-light-mode.el, but couldn't install it over my existing one because the version number didn't change.  In general it is good to bump the version number after any useful change.